### PR TITLE
Add white-space normal for pre elements

### DIFF
--- a/server/public/src/site.css
+++ b/server/public/src/site.css
@@ -126,7 +126,7 @@ nav .nav > li{
 }
 
 #playground textarea {
-  white-space: pre;
+  white-space: normal;
   margin-top: 50px;
   border-bottom-left-radius: 0;
   border-bottom-right-radius: 0;
@@ -168,4 +168,8 @@ nav .nav > li{
 
 .iframe-wrapper>iframe svg {
   width: 100%;
+}
+
+pre {
+  white-space: normal;
 }


### PR DESCRIPTION
This is due to scroll bars appearing for pre's in chrome v49.
Also removed scroll bars for playground's textarea

See https://jsfiddle.net/8z978sbw/
